### PR TITLE
added all-tool flag to az install

### DIFF
--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -144,5 +144,8 @@ short-summary: Update a CAPI management cluster.
 
 helps['capi install'] = """
 type: command
-short-summary: installs all needed tools
+short-summary: installs needed tools
+parameters:
+  - name: --all-tools
+    short-summary: Install all needed and optional tools
 """

--- a/src/capi/azext_capi/_help.py
+++ b/src/capi/azext_capi/_help.py
@@ -141,3 +141,8 @@ helps['capi management update'] = """
 type: command
 short-summary: Update a CAPI management cluster.
 """
+
+helps['capi install'] = """
+type: command
+short-summary: installs all needed tools
+"""

--- a/src/capi/azext_capi/commands.py
+++ b/src/capi/azext_capi/commands.py
@@ -24,6 +24,7 @@ def load_command_table(self, _):
         g.custom_command('show', 'show_workload_cluster',
                          table_transformer=CLUSTER_TABLE_FORMAT)
         g.custom_command('update', 'update_workload_cluster')
+        g.custom_command('install', 'install_tools')
 
     with self.command_group('capi management', is_preview=True) as g:
         g.custom_command('create', 'create_management_cluster')

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -782,10 +782,16 @@ def show_workload_cluster(cmd, capi_name):  # pylint: disable=unused-argument
 def update_workload_cluster(cmd, capi_name):
     raise NotImplementedError
 
+def install_tools(cmd):
+    logger.info('Checking if required tools are installed')
+    check_tools(cmd, True)
 
-def check_prereqs(cmd, install=False):
+def check_tools(cmd, install=False):
     check_kubectl(cmd, install)
     check_clusterctl(cmd, install)
+
+def check_prereqs(cmd, install=False):
+    check_tools(cmd, install)
 
     # Check for required environment variables
     # TODO: remove this when AAD Pod Identity becomes the default

--- a/src/capi/azext_capi/custom.py
+++ b/src/capi/azext_capi/custom.py
@@ -782,13 +782,19 @@ def show_workload_cluster(cmd, capi_name):  # pylint: disable=unused-argument
 def update_workload_cluster(cmd, capi_name):
     raise NotImplementedError
 
-def install_tools(cmd):
-    logger.info('Checking if required tools are installed')
-    check_tools(cmd, True)
 
-def check_tools(cmd, install=False):
+def install_tools(cmd, all_tools=False):
+    logger.info('Checking if required tools are installed')
+    check_tools(cmd, install=True, all_tools=all_tools)
+
+
+def check_tools(cmd, install=False, all_tools=False):
     check_kubectl(cmd, install)
     check_clusterctl(cmd, install)
+    if not all_tools:
+        return
+    check_kind(cmd, install)
+
 
 def check_prereqs(cmd, install=False):
     check_tools(cmd, install)


### PR DESCRIPTION
<!--
To add a feature or change an existing one, please begin by submitting a markdown document
that briefly describes your proposal. This will allow others to review and suggest improvements
before you move forward with implementation.
-->

**Description**
This PR aims to added `--all-tools` flag to `az capi install`
and fix lint errors
**History Notes**

<!--
Please summarize this PR for a reader of the history file. Make sure to note any breaking changes,
and update HISTORY.rst with the summary, such as:

BREAKING CHANGE: az capi create: Change arguments and require "--location".
az capi list: Add --output=table mode.
-->

---

This checklist is used to make sure that common guidelines for an Azure CLI pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
